### PR TITLE
DRAFT: noble g++ 13.2

### DIFF
--- a/apps/gadgetron/main.cpp
+++ b/apps/gadgetron/main.cpp
@@ -65,11 +65,11 @@ int main(int argc, char *argv[]) {
                 "Output file for binary data as a result of a local reconstruction")
             ("config_name,c",
                 value<std::string>(),
-                "Filename of the desired gadgetron reconstruction config.")
-            ("parameter",
-                value<std::vector<gadget_parameter>>(),
-                "Parameter to be passed to the gadgetron reconstruction config. Multiple parameters can be passed."
-                "Format: --parameter <name>=<value> --parameter <name>=<value> ...");
+                "Filename of the desired gadgetron reconstruction config.");
+//            ("parameter",
+//                value<std::vector<gadget_parameter>>(),
+//                "Parameter to be passed to the gadgetron reconstruction config. Multiple parameters can be passed.");
+//                "Format: --parameter <name>=<value> --parameter <name>=<value> ...");
 
 
     options_description storage_options("Storage options");

--- a/core/Response.h
+++ b/core/Response.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 namespace Gadgetron::Core {
     struct Response {

--- a/core/gadgetron_paths.cpp
+++ b/core/gadgetron_paths.cpp
@@ -1,5 +1,6 @@
 #include "log.h"
 #include "gadgetron_paths.h"
+#include <memory>
 
 #if defined _WIN32 || _WIN64
 #include <libloaderapi.h>

--- a/toolboxes/core/cpu/hoNDArray_utils.h
+++ b/toolboxes/core/cpu/hoNDArray_utils.h
@@ -205,6 +205,8 @@ namespace Gadgetron {
         const hoNDArray<T> permuteArray(dim_permute, const_cast<T*>(in.get_data_ptr()), false);
 
         // starting index for in and out array for every permute memcpy operation
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfree-nonheap-object"
         std::vector<size_t> ind_permute_in(dim_permute.size(), 0), ind_in(nDim, 0), ind_out(nDim, 0);
 
         for (n = 0; n < num_memcpy; n++) {
@@ -222,6 +224,7 @@ namespace Gadgetron {
             memcpy(o + offset_out, in.begin() + offset_in, sizeof(T)*stride);
         }
     }
+#pragma GCC diagnostic pop
   }
 
   // Expand array to new dimension


### PR DESCRIPTION
This should not be merged in yet!

This is a record of issues that need to be investigated for gadgetron to work in noble with g++13.2.  The main issues are
1) a free-noheap-object compiling error on vectors in hoNDArray_utils.h 
and 
2) the use of a non-string vector in boost's program options.